### PR TITLE
Bug fix rabbitmq

### DIFF
--- a/generator/property_metadata.go
+++ b/generator/property_metadata.go
@@ -190,6 +190,11 @@ func (p *PropertyMetadata) PropertyType(propertyName string) PropertyValue {
 			}
 		}
 	}
+	if p.IsMultiSelect() {
+		return &MultiSelectorValue{
+			Value: []string{fmt.Sprintf("((%s))", propertyName)},
+		}
+	}
 	if p.IsCertificate() {
 		return &CertificateValueHolder{
 			Value: &CertificateValue{

--- a/generator/value_types.go
+++ b/generator/value_types.go
@@ -53,6 +53,18 @@ func (s *SelectorValue) IsSelector() bool {
 	return true
 }
 
+type MultiSelectorValue struct {
+	Value []string `yaml:"value"`
+}
+
+func (s *MultiSelectorValue) Parameters() []string {
+	return []string{fmt.Sprintf("selector -> %s", s.Value)}
+}
+
+func (s *MultiSelectorValue) IsSelector() bool {
+	return true
+}
+
 type SimpleValue struct {
 	Value string `yaml:"value"`
 }

--- a/generator/value_types.go
+++ b/generator/value_types.go
@@ -58,11 +58,11 @@ type MultiSelectorValue struct {
 }
 
 func (s *MultiSelectorValue) Parameters() []string {
-	return []string{fmt.Sprintf("selector -> %s", s.Value)}
+	return s.Value
 }
 
 func (s *MultiSelectorValue) IsSelector() bool {
-	return true
+	return false
 }
 
 type SimpleValue struct {


### PR DESCRIPTION
Rabbit MQ 1.14.4 tile has a multi-select field that is required.  The Tile Config Generator didn't take this into account when generating the template file.  It created it as a `SimpleValue`, but needed the value to be an array.

I added a new type, `MultiSelectorValue` that behaves the same as a `SimpleValue` but the value filed is an array instead of a string.